### PR TITLE
Feature/latency tracking

### DIFF
--- a/python/examples/latency_tracking.py
+++ b/python/examples/latency_tracking.py
@@ -1,0 +1,61 @@
+# !/usr/bin/env python
+# coding: utf-8
+
+"""
+Example of how to track WebSocket latency with local timestamps.
+"""
+
+import time
+import logging
+import asyncio
+from gate_ws import Configuration, Connection, WebSocketResponse
+from gate_ws.spot import SpotPublicTradeChannel
+
+logger = logging.getLogger(__name__)
+
+
+async def on_trade(conn: Connection, response: WebSocketResponse):
+    # Local timestamp is injected into the 'result' dictionary
+    data = response.result
+
+    assert '_local_ts' in data, "Local timestamp not found in data"
+    local_ts = data['_local_ts']
+    
+    # Immitation of local processing
+    await asyncio.sleep(0.05) 
+
+    now_ns = int(time.time() * 1_000_000_000)
+    latency_ns = now_ns - local_ts
+    latency_ms = latency_ns / 1_000_000
+    logger.info(f"[TRADE] Price: {data.get('price')}, Latency: {latency_ms:.3f} ms")
+
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s: %(message)s")
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    cfg = Configuration(
+        event_loop=loop,
+        add_local_ts=True # Enable local timestamp feature
+    )
+
+    conn = Connection(cfg)
+    channel = SpotPublicTradeChannel(conn, on_trade)
+    channel.subscribe(["BTC_USDT"])
+
+    tasks: set[asyncio.Task] = {
+        loop.create_task(conn.run()),
+    }
+
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt:
+        for task in tasks:
+            task.cancel()
+
+        group = asyncio.gather(*tasks, return_exceptions=True)
+        loop.run_until_complete(group)
+    finally:
+        loop.close()

--- a/python/gate_ws/client.py
+++ b/python/gate_ws/client.py
@@ -37,6 +37,7 @@ class Configuration(object):
         event_loop=None,
         executor_pool=None,
         default_callback=None,
+        add_local_ts: bool = False,
         ping_interval: int = 5,
         max_retry: int = 10,
         verify: bool = True,
@@ -71,6 +72,7 @@ class Configuration(object):
         self.loop = event_loop
         self.pool = executor_pool
         self.default_callback = default_callback
+        self.add_local_ts = add_local_ts
         self.ping_interval = ping_interval
         self.max_retry = max_retry
         self.verify = verify
@@ -162,7 +164,7 @@ class ApiRequest(object):
 
 
 class WebSocketResponse(object):
-    def __init__(self, body: str):
+    def __init__(self, body: str, local_ts: int = None):
         self.body = body
         msg = json.loads(body)
         self.channel = msg.get("channel") or (msg.get("header") or {}).get("channel")
@@ -170,12 +172,18 @@ class WebSocketResponse(object):
             raise ValueError("no channel found from response message: %s" % body)
 
         self.timestamp = msg.get("time")
+        self.local_ts = local_ts
+
         self.event = msg.get("event")
         self.result = (
             msg.get("result")
             or (msg.get("data") or {}).get("result")
             or (msg.get("data") or {}).get("errs")
         )
+
+        if self.result and self.local_ts:
+            self.result["_local_ts"] = self.local_ts
+
         self.error = None
         if msg.get("error"):
             self.error = GateWebsocketError(
@@ -230,7 +238,13 @@ class Connection(object):
 
     async def _read(self, conn: websockets.WebSocketClientProtocol):
         async for msg in conn:
-            response = WebSocketResponse(msg)
+            
+            if self.cfg.add_local_ts:
+                local_ts = int(time.time() * 1_000_000_000)
+            else:
+                local_ts = None
+            
+            response = WebSocketResponse(msg, local_ts=local_ts)
             callback = self.channels.get(response.channel, self.cfg.default_callback)
             if callback is not None:
                 if asyncio.iscoroutinefunction(callback):


### PR DESCRIPTION
## Summary
Add optional `local_ts` field for end-to-end latency measurement (WebSocket
message → user callback). This is a follow-up to #73.

## Changes
- `Configuration`: add `add_local_ts: bool = False` parameter
- `Connection._read`: capture `int(time.time() * 1_000_000_000)` before parsing
- `WebSocketResponse`: inject `_local_ts` into `result` dict when enabled
- `examples/latency_tracking.py`: demonstrate usage

## Backward Compatibility
Fully backward compatible. Uses `time.time()` for compatibility with Python 3.6+.
Default behaviour unchanged.

## Related
- #73