### PR TITLE
fix: replace deprecated asyncio.get_event_loop() in Configuration

### DIFF
--- a/python/gate_ws/client.py
+++ b/python/gate_ws/client.py
@@ -193,7 +193,7 @@ class Connection(object):
         self.sending_queue = asyncio.Queue()
         self.sending_history = list()
         self.event_loop: asyncio.AbstractEventLoop = (
-            cfg.loop or asyncio.get_event_loop()
+            cfg.loop or asyncio.new_event_loop()
         )
         self.main_loop = None
 


### PR DESCRIPTION
## Summary
Replace deprecated `asyncio.get_event_loop()` in `Configuration` with `asyncio.new_event_loop()`.

This is a follow-up to #73, removing the last deprecated asyncio call from the core SDK.

## Related
- #73